### PR TITLE
fix: correcting text stroke

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -147,8 +147,8 @@ export function createMapAreaFeature({
       text: new Text({
         text: feature.get("name") || name, // <-- use feature argument
         font: "bold 18px sans-serif",
-        //fill: new Fill({ color: "#222" }),
-        //stroke: new Stroke({ color: "#fff", width: 3 }),
+        fill: new Fill({ color: "#222" }),
+        stroke: new Stroke({ color: "#fff", width: 3 }),
         overflow: true,
       }),
     });


### PR DESCRIPTION
text was hard to read without stroke, was mistakenly removed